### PR TITLE
Sync wrap with FluidSynth 2.2.2 release

### DIFF
--- a/include/fluidsynth/meson.build
+++ b/include/fluidsynth/meson.build
@@ -1,0 +1,12 @@
+fluidsynth_versions = meson.project_version().split('.')
+
+fluidsynth_versions_conf = {
+  'FLUIDSYNTH_VERSION'       : '"@0@"'.format(meson.project_version()),
+  'FLUIDSYNTH_VERSION_MAJOR' : fluidsynth_versions[0].to_int(),
+  'FLUIDSYNTH_VERSION_MINOR' : fluidsynth_versions[1].to_int(),
+  'FLUIDSYNTH_VERSION_MICRO' : fluidsynth_versions[2].to_int(),
+}
+
+configure_file(input : 'version.h.in',
+               output : 'version.h',
+               configuration : fluidsynth_versions_conf)

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,4 @@
+configure_file(input : 'fluidsynth.cmake',
+               output : 'fluidsynth.h',
+               format : 'cmake',
+               configuration : {'BUILD_SHARED_LIBS': 1}) # FIXME shared?

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,113 @@
+project('fluidsynth', 'c', 'cpp',
+        version : '2.2.2',
+        license : 'LGPL-2.1-or-later',
+        default_options : ['b_ndebug=if-release'],
+        meson_version : '>= 0.53.0')
+
+cc = meson.get_compiler('c')
+
+summary('Build type',     get_option('buildtype'), section : 'Build Summary')
+summary('Install prefix', get_option('prefix'),    section : 'Build Summary')
+
+
+# config file
+#
+# TODO there are many, many more options to set/detect in upstream template
+#      see meson_options.txt for list
+
+conf = configuration_data()
+
+conf.set('PACKAGE', meson.project_name())
+conf.set('DEFAULT_SOUNDFONT', get_option('datadir') / 'soundfonts' / 'default.sf2')
+conf.set('TEST_SOUNDFONT', meson.current_source_dir() / 'sf2' / 'VintageDreamsWaves-v2.sf2')
+conf.set('TEST_SOUNDFONT_SF3', meson.current_source_dir() / 'sf2' / 'VintageDreamsWaves-v2.sf3')
+conf.set('STDC_HEADERS', 1)
+conf.set('SUPPORTS_VLA', 1) # some check for ancient compilers
+
+if host_machine.system() == 'darwin'
+  conf.set('DARWIN', 1)
+endif
+
+if host_machine.endian() == 'big'
+  conf_data.set('WORDS_BIGENDIAN', 1)
+endif
+
+if get_option('enable-floats')
+  conf.set('WITH_FLOAT', 1)
+endif
+summary('Samples type', conf.has('WITH_FLOAT').to_string('float', 'double'),
+        section : 'Developer nerds info')
+
+headers_to_check = [
+  'arpa/inet.h',        'errno.h',            'fcntl.h',
+  'getopt.h',           'inttypes.h',         'io.h',
+  'limits.h',           'linux/soundcard.h',  'machine/soundcard.h',
+  'math.h',             'netinet/in.h',       'netinet/tcp.h',
+  'pthread.h',          'signal.h',           'stdarg.h',
+  'stdint.h',           'stdio.h',            'stdlib.h',
+  'string.h',           'strings.h',          'sys/mman.h',
+  'sys/socket.h',       'sys/soundcard.h',    'sys/stat.h',
+  'sys/time.h',         'sys/types.h',        'unistd.h',
+  'windows.h',
+]
+
+foreach h : headers_to_check 
+  conf.set10('HAVE_' + h.underscorify().to_upper(), cc.has_header(h))
+endforeach
+
+if cc.has_function('inet_ntop', prefix : '#include <arpa/inet.h>')
+  conf.set('HAVE_INETNTOP', 1) # lib uses ifdef for this one
+endif
+
+foreach fun : ['sinf', 'cosf', 'fabsf', 'powf', 'sqrtf', 'logf']
+  conf.set10('HAVE_' + fun.to_upper(), cc.has_function(fun))
+endforeach
+
+
+# external dependencies
+
+m_dep       = cc.find_library('m', required : false)
+glib_dep    = dependency('glib-2.0', static : get_option('try-static-deps'))
+gthread_dep = dependency('gthread-2.0', static : get_option('try-static-deps'))
+openmp_dep  = dependency('openmp', required : false, language : 'c',
+                         version : '>= 4.0')
+
+if openmp_dep.found()
+  conf.set('HAVE_OPENMP', 1)
+endif
+summary('OpenMP 4.0', openmp_dep.found().to_string('yes', 'no'),
+        section : 'Developer nerds info')
+
+if get_option('enable-threads')
+  conf.set('ENABLE_MIXER_THREADS', 1)
+endif
+summary('Multi-threading', conf.has('ENABLE_MIXER_THREADS').to_string('yes', 'no'),
+        section : 'Developer nerds info')
+
+# config.h
+
+configure_file(input : 'src/config.cmake',
+               output : 'config.h',
+               format : 'cmake@',
+               configuration : conf)
+
+
+# fluidsynth lib
+
+subdir('include')
+subdir('include/fluidsynth')
+subdir('src')
+
+lib_includes = [include_directories('.', 'include'), src_includes]
+dep_includes = include_directories('include')
+
+fluidsynth_lib = library('fluidsynth', fluidsynth_sources, gen_tables,
+                         dependencies : [m_dep, glib_dep, gthread_dep, openmp_dep],
+                         include_directories : lib_includes)
+
+fluidsynth_dep = declare_dependency(link_with : fluidsynth_lib,
+                                    include_directories : dep_includes)
+
+# unit tests
+
+subdir('test')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,57 @@
+# Options disabled by default
+
+option('enable-floats', type : 'boolean', value : false,
+       description : 'enable type float instead of double for DSP samples')
+
+option('enable-threads', type : 'boolean', value : true,
+       description : 'enable multi-threading support (such as parallel voice synthesis)')
+
+# TODO enable-fpe-check   'enable Floating Point Exception checks and debug messages'
+# TODO enable-portaudio   'compile PortAudio support'
+# TODO enable-profiling   'profile the dsp code'
+# TODO enable-trap-on-fpe 'enable SIGFPE trap on Floating Point Exceptions'
+
+# Options enabled by default
+
+# TODO enable-aufile       'compile support for sound file output'
+# TODO BUILD_SHARED_LIBS   'Build a shared object or DLL'
+# TODO enable-dbus         'compile DBUS support (if it is available)'
+# TODO enable-ipv6         'enable ipv6 support'
+# TODO enable-jack         'compile JACK support (if it is available)'
+# TODO enable-ladspa       'enable LADSPA effect units'
+# TODO enable-libinstpatch 'use libinstpatch (if available) to load DLS and GIG files'
+# TODO enable-libsndfile   'compile libsndfile support (if it is available)'
+# TODO enable-midishare    'compile MidiShare support (if it is available)'
+# TODO enable-opensles     'compile OpenSLES support (if it is available)'          # upstream has it disabled!
+# TODO enable-oboe         'compile Oboe support (requires OpenSLES and/or AAudio)' # upstream has it disabled!
+# TODO enable-network      'enable network support (requires BSD sockets)'
+# TODO enable-oss          'compile OSS support (if it is available)'
+# TODO enable-dsound       'compile DirectSound support (if it is available)'
+# TODO enable-waveout      'compile Windows WaveOut support (if it is available)'
+# TODO enable-winmidi      'compile Windows MIDI support (if it is available)'
+# TODO enable-sdl2         'compile SDL2 audio support (if it is available)'
+# TODO enable-pkgconfig    'use pkg-config to locate fluidsynth\'s (mostly optional) dependencies'
+# TODO enable-pulseaudio   'compile PulseAudio support (if it is available)'
+# TODO enable-readline     'compile readline lib line editing (if it is available)'
+
+# Platform specific options
+
+# Linux|FreeBSD|DragonFly
+# TODO enable-lash 'compile LASH support (if it is available)'
+# TODO enable-alsa 'compile ALSA support (if it is available)'
+#
+# Linux
+# TODO enable-systemd 'compile systemd support (if it is available)'
+#
+# Darwin
+# TODO enable-coreaudio 'compile CoreAudio support (if it is available)'
+# TODO enable-coremidi  'compile CoreMIDI support (if it is available)'
+# TODO enable-framework 'create a Mac OSX style FluidSynth.framework'
+#
+# OS2
+# TODO enable-dart 'compile DART support (if it is available)'
+
+# Wrap-specific options
+
+option('try-static-deps', type : 'boolean', value : false,
+       description : 'try using static linking for FluidSynth dependencies')

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,21 @@
 This repository contains a Meson build definition for project fluidsynth.
 
 For more information please see http://mesonbuild.com.
+
+For more information about fluidsynth library see https://github.com/FluidSynth/fluidsynth
+
+This wrap DOES NOT provide full functionality of fluidsynth library, only
+some features are available for now; see meson_options.txt for details.
+
+To use this wrap:
+
+    $ meson wrap install fluidsynth
+    $ echo 'fluidsynth*' >> subprojects/.gitignore
+
+Then create a dependency object in meson.build of your project:
+
+    fluidsynth_dep = dependency('fluidsynth')
+
+For meson < 0.55.0 wrap fallbacks need to be explicitly enabled:
+
+    fluidsynth_dep = dependency('fluidsynth', fallback : ['fluidsynth', 'fluidsynth_dep'])

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,68 @@
+src_includes = include_directories(
+  '.',
+  'bindings',
+  'drivers',
+  'midi',
+  'rvoice',
+  'sfloader',
+  'synth',
+  'utils',
+)
+
+fluidsynth_sources = files(
+  'bindings/fluid_cmd.c',
+  'bindings/fluid_filerenderer.c',
+  'bindings/fluid_ladspa.c',
+  'drivers/fluid_adriver.c',
+  'drivers/fluid_mdriver.c',
+  'midi/fluid_midi.c',
+  'midi/fluid_midi_router.c',
+  'midi/fluid_seq.c',
+  'midi/fluid_seq_queue.cpp',
+  'midi/fluid_seqbind.c',
+  'midi/fluid_seqbind_notes.cpp',
+  'rvoice/fluid_adsr_env.c',
+  'rvoice/fluid_chorus.c',
+  'rvoice/fluid_iir_filter.c',
+  'rvoice/fluid_lfo.c',
+  'rvoice/fluid_rev.c',
+  'rvoice/fluid_rvoice.c',
+  'rvoice/fluid_rvoice_dsp.c',
+  'rvoice/fluid_rvoice_event.c',
+  'rvoice/fluid_rvoice_mixer.c',
+  'sfloader/fluid_defsfont.c',
+  'sfloader/fluid_samplecache.c',
+  'sfloader/fluid_sffile.c',
+  'sfloader/fluid_sfont.c',
+  'synth/fluid_chan.c',
+  'synth/fluid_event.c',
+  'synth/fluid_gen.c',
+  'synth/fluid_mod.c',
+  'synth/fluid_synth.c',
+  'synth/fluid_synth_monopoly.c',
+  'synth/fluid_tuning.c',
+  'synth/fluid_voice.c',
+  'utils/fluid_conv.c',
+  'utils/fluid_hash.c',
+  'utils/fluid_list.c',
+  'utils/fluid_ringbuffer.c',
+  'utils/fluid_settings.c',
+  'utils/fluid_sys.c',
+)
+
+make_tables_sources = files(
+  'gentables/gen_conv.c',
+  'gentables/gen_rvoice_dsp.c',
+  'gentables/make_tables.c',
+)
+
+make_tables_exe = executable('make_tables', make_tables_sources,
+                             native : true,
+                             dependencies : m_dep,
+                             include_directories : '.')
+
+fluid_tables = ['fluid_conv_tables.inc.h', 'fluid_rvoice_dsp_tables.inc.h']
+
+gen_tables = custom_target('gen_tables',
+                           command : [make_tables_exe, meson.current_build_dir() + '/'],
+                           output : fluid_tables)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,26 @@
+fluid_tests = [
+  'test_sample_cache',
+  'test_sfont_loading',
+  'test_sample_rate_change',
+  'test_preset_sample_loading',
+  'test_bug_635',
+  'test_settings_unregister_callback',
+  'test_pointer_alignment',
+  'test_seqbind_unregister',
+  'test_synth_chorus_reverb',
+  'test_snprintf',
+  'test_synth_process',
+  'test_ct2hz',
+  'test_sample_validate',
+  'test_jack_obtaining_synth',
+  'test_sfont_unloading',
+  'test_seq_scale',
+  'test_seq_event_queue_sort', # this test takes ~70s
+]
+
+foreach name : fluid_tests
+  exe = executable(name, name + '.c',
+                   dependencies : [fluidsynth_dep, glib_dep],
+                   include_directories : lib_includes)
+  test(name, exe, timeout : 100)
+endforeach

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = fluidsynth-2.2.2
+source_url = https://github.com/FluidSynth/fluidsynth/archive/v2.2.2.tar.gz
+source_filename = fluidsynth-2.2.2.tar.gz
+source_hash =  695aedbfd53160fef7a9a1f66cd6d5cc8a5da0fd472eee458d82b848b6065f9a
+[provide]
+fluidsynth = fluidsynth_dep


### PR DESCRIPTION
FluidSynth 2.2.2 was released 11 July, 2021

Release notes:
   https://github.com/FluidSynth/fluidsynth/releases/tag/v2.2.2

This is just a fix-revision. Tested and working with DOSBox Staging.